### PR TITLE
演習3-3（外国語レッスンのマッチングサービス3週目）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,3 +17,15 @@
 table, td, th {
   border: 1px solid;
   }
+
+.high{
+  background-color: red;
+  }
+
+.middle{
+  background-color: pink;
+  }
+
+.low{
+  background-color: mediumturquoise;
+  }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+table, td, th {
+  border: 1px solid;
+  }

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,4 +1,6 @@
 class AdminsController < ApplicationController
+  before_action :authenticate_admin!
+  
   def show
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,6 +1,6 @@
 class AdminsController < ApplicationController
   before_action :authenticate_admin!
-  
+
   def show
   end
 end

--- a/app/controllers/language_reservation_rates_controller.rb
+++ b/app/controllers/language_reservation_rates_controller.rb
@@ -7,7 +7,7 @@ class LanguageReservationRatesController < ApplicationController
     @from = @today.beginning_of_month
     @to = @today.end_of_month
     @dates_in_month = @from.upto(@to)
-    @dates_for_week = @dates_in_month.slice_before{|date| date.wday.zero?}.to_a
+    @dates_for_week = @dates_in_month.slice_before { |date| date.wday.zero? }.to_a
     @days = %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
   end
 end

--- a/app/controllers/language_reservation_rates_controller.rb
+++ b/app/controllers/language_reservation_rates_controller.rb
@@ -1,0 +1,11 @@
+class LanguageReservationRatesController < ApplicationController
+  def show
+    @language = Language.find(params[:language])
+    @today = Date.current
+    @from = @today.beginning_of_month
+    @to = @today.end_of_month
+    @dates_in_month = @from.upto(@to)
+    @dates_for_week = @dates_in_month.slice_before{|date| date.wday.zero?}.to_a
+    @days = %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
+  end
+end

--- a/app/controllers/language_reservation_rates_controller.rb
+++ b/app/controllers/language_reservation_rates_controller.rb
@@ -1,4 +1,6 @@
 class LanguageReservationRatesController < ApplicationController
+  before_action :authenticate_admin!
+
   def show
     @language = Language.find(params[:language])
     @today = Date.current

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,4 +1,6 @@
 class LanguagesController < ApplicationController
+  before_action :authenticate_admin!
+
   def show
     @languages = Language.all.page(params[:page])
   end

--- a/app/controllers/lesson_reservations_controller.rb
+++ b/app/controllers/lesson_reservations_controller.rb
@@ -1,4 +1,6 @@
 class LessonReservationsController < ApplicationController
+  before_action :authenticate_student!
+
   def create
     if current_student.remaining_lesson_count <= 0
       redirect_to lessons_path, alert: 'チケットを購入してください'

--- a/app/controllers/purchase_tickets_controller.rb
+++ b/app/controllers/purchase_tickets_controller.rb
@@ -1,4 +1,6 @@
 class PurchaseTicketsController < ApplicationController
+  before_action :authenticate_student!
+
   def new
     @purchase_ticket = current_student.purchase_tickets.new
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,4 +1,6 @@
 class ReviewsController < ApplicationController
+  before_action :authenticate_teacher!, only: %i[new create destroy]
+
   def new
     @review = current_teacher.reviews.new(lesson_id: params[:lesson])
   end

--- a/app/controllers/students/application_controller.rb
+++ b/app/controllers/students/application_controller.rb
@@ -1,0 +1,3 @@
+class Students::ApplicationController < ApplicationController
+  before_action :authenticate_student!
+end

--- a/app/controllers/students/lessons_controller.rb
+++ b/app/controllers/students/lessons_controller.rb
@@ -1,4 +1,4 @@
-class Students::LessonsController < ApplicationController
+class Students::LessonsController < Students::ApplicationController
   def show
     @lessons = current_student.lessons.after_current
   end

--- a/app/controllers/students/past_lessons_controller.rb
+++ b/app/controllers/students/past_lessons_controller.rb
@@ -1,4 +1,6 @@
-class Students::PastLessonsController < ApplicationController
+class Students::PastLessonsController < Students::ApplicationController
+  skip_before_action :authenticate_student!, if: :teacher_signed_in?
+  
   def show
     @student = Student.find(params[:student])
     @lessons = @student.lessons.past.page(params[:page])

--- a/app/controllers/students/past_lessons_controller.rb
+++ b/app/controllers/students/past_lessons_controller.rb
@@ -1,6 +1,6 @@
 class Students::PastLessonsController < Students::ApplicationController
   skip_before_action :authenticate_student!, if: :teacher_signed_in?
-  
+
   def show
     @student = Student.find(params[:student])
     @lessons = @student.lessons.past.page(params[:page])

--- a/app/controllers/students/registrations_controller.rb
+++ b/app/controllers/students/registrations_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Students::RegistrationsController < Devise::RegistrationsController
+  around_action :wrap_in_transaction, only: :create
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
-  after_action :create_purchase_ticket, only: %i[create]
+  # after_action :create_purchase_ticket, only: %i[create]
 
   # GET /resource/sign_up
   # def new
@@ -63,6 +64,13 @@ class Students::RegistrationsController < Devise::RegistrationsController
 
   def create_purchase_ticket
     ticket_id = Ticket.find_by(fee: 2200).id
-    current_student.purchase_tickets.create(ticket_id: ticket_id)
+    current_student.purchase_tickets.create!(ticket_id: ticket_id)
+  end
+
+  def wrap_in_transaction
+    ActiveRecord::Base.transaction do
+      yield
+      create_purchase_ticket
+    end
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,5 +1,5 @@
 class StudentsController < ApplicationController
-  before_action :authenticate_student! 
+  before_action :authenticate_student!
 
   def show
     @student = current_student

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,5 +1,7 @@
 class StudentsController < ApplicationController
+  before_action :authenticate_student! 
+
   def show
-    @student = Student.find(params[:id])
+    @student = current_student
   end
 end

--- a/app/controllers/teacher_reservation_rates_controller.rb
+++ b/app/controllers/teacher_reservation_rates_controller.rb
@@ -1,0 +1,11 @@
+class TeacherReservationRatesController < ApplicationController
+  def show
+    @teacher = Teacher.find(params[:teacher])
+    @today = Date.current
+    @from = @today.beginning_of_month
+    @to = @today.end_of_month
+    @dates_in_month = @from.upto(@to)
+    @dates_for_week = @from.upto(@to).slice_before{ |date| date.wday.zero? }.to_a
+    @days = %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
+  end
+end

--- a/app/controllers/teacher_reservation_rates_controller.rb
+++ b/app/controllers/teacher_reservation_rates_controller.rb
@@ -1,13 +1,13 @@
 class TeacherReservationRatesController < ApplicationController
   before_action :authenticate_admin!
-  
+
   def show
     @teacher = Teacher.find(params[:teacher])
     @today = Date.current
     @from = @today.beginning_of_month
     @to = @today.end_of_month
     @dates_in_month = @from.upto(@to)
-    @dates_for_week = @from.upto(@to).slice_before{ |date| date.wday.zero? }.to_a
+    @dates_for_week = @from.upto(@to).slice_before { |date| date.wday.zero? }.to_a
     @days = %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
   end
 end

--- a/app/controllers/teacher_reservation_rates_controller.rb
+++ b/app/controllers/teacher_reservation_rates_controller.rb
@@ -1,4 +1,6 @@
 class TeacherReservationRatesController < ApplicationController
+  before_action :authenticate_admin!
+  
   def show
     @teacher = Teacher.find(params[:teacher])
     @today = Date.current

--- a/app/controllers/teachers/application_controller.rb
+++ b/app/controllers/teachers/application_controller.rb
@@ -1,0 +1,3 @@
+class Teachers::ApplicationController < ApplicationController
+  before_action :authenticate_teacher!
+end

--- a/app/controllers/teachers/lessons_controller.rb
+++ b/app/controllers/teachers/lessons_controller.rb
@@ -1,4 +1,4 @@
-class Teachers::LessonsController < ApplicationController
+class Teachers::LessonsController < Teachers::ApplicationController
   def show
     @lessons = current_teacher.lessons.after_current.page(params[:page])
   end

--- a/app/controllers/teachers/multiple_lessons_controller.rb
+++ b/app/controllers/teachers/multiple_lessons_controller.rb
@@ -1,0 +1,16 @@
+class Teachers::MultipleLessonsController < ApplicationController
+  def new
+  end
+
+  def create
+    started_at_ary = params[:multiple_lessons][:started_at].without("")
+    if started_at_ary.count.zero?
+      render :new
+    else
+      started_at_ary.each do |started_at|
+        current_teacher.lessons.create!(started_at: started_at)  if started_at.present?
+      end
+      redirect_to teachers_lesson_path, notice: 'レッスンを複数作成しました'
+    end
+  end
+end

--- a/app/controllers/teachers/multiple_lessons_controller.rb
+++ b/app/controllers/teachers/multiple_lessons_controller.rb
@@ -3,12 +3,12 @@ class Teachers::MultipleLessonsController < Teachers::ApplicationController
   end
 
   def create
-    started_at_ary = params[:multiple_lessons][:started_at].without("")
+    started_at_ary = params[:multiple_lessons][:started_at].without('')
     if started_at_ary.count.zero?
       render :new
     else
       started_at_ary.each do |started_at|
-        current_teacher.lessons.create!(started_at: started_at)  if started_at.present?
+        current_teacher.lessons.create!(started_at: started_at) if started_at.present?
       end
       redirect_to teachers_lesson_path, notice: 'レッスンを複数作成しました'
     end

--- a/app/controllers/teachers/multiple_lessons_controller.rb
+++ b/app/controllers/teachers/multiple_lessons_controller.rb
@@ -1,4 +1,4 @@
-class Teachers::MultipleLessonsController < ApplicationController
+class Teachers::MultipleLessonsController < Teachers::ApplicationController
   def new
   end
 

--- a/app/controllers/teachers/past_lessons_controller.rb
+++ b/app/controllers/teachers/past_lessons_controller.rb
@@ -1,4 +1,4 @@
-class Teachers::PastLessonsController < ApplicationController
+class Teachers::PastLessonsController < Teachers::ApplicationController
   def show
     @lessons = current_teacher.lessons.past.reserved.page(params[:page])
   end

--- a/app/controllers/teachers/specific_range_lessons_controller.rb
+++ b/app/controllers/teachers/specific_range_lessons_controller.rb
@@ -1,0 +1,20 @@
+class Teachers::SpecificRangeLessonsController < Teachers::ApplicationController
+  def new
+  end
+
+  def create
+    date = params[:date].in_time_zone
+    start_time = params[:start_time].to_i
+    end_time = params[:end_time].to_i
+    time_range = (start_time..end_time).to_a
+    if !time_range.present? || !date.present?
+      render :new
+    else
+      time_range.each do |time|
+        started_at = date + time.hour
+        current_teacher.lessons.create(started_at: started_at)
+      end
+      redirect_to teachers_lesson_path, notice: 'レッスンを範囲指定で作成しました'
+    end
+  end
+end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,4 +1,7 @@
 class TeachersController < ApplicationController
+  before_action :authenticate_admin! , only: %i[index new create destroy]
+  before_action :authenticate_teacher!, only: %i[show], unless: :admin_signed_in?
+
   def index
     @teachers = Teacher.all.page(params[:page])
   end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,5 +1,5 @@
 class TeachersController < ApplicationController
-  before_action :authenticate_admin! , only: %i[index new create destroy]
+  before_action :authenticate_admin!, only: %i[index new create destroy]
   before_action :authenticate_teacher!, only: %i[show], unless: :admin_signed_in?
 
   def index

--- a/app/controllers/time_reservation_rates_controller.rb
+++ b/app/controllers/time_reservation_rates_controller.rb
@@ -1,0 +1,11 @@
+class TimeReservationRatesController < ApplicationController
+  before_action :authenticate_admin!
+  
+  def show
+    @today = Date.current
+    @from = @today.beginning_of_month
+    @to = @today.end_of_month
+    @dates_in_month = (@from..@to).to_a
+    @times = (7..22).to_a.freeze
+  end
+end

--- a/app/controllers/time_reservation_rates_controller.rb
+++ b/app/controllers/time_reservation_rates_controller.rb
@@ -1,6 +1,6 @@
 class TimeReservationRatesController < ApplicationController
   before_action :authenticate_admin!
-  
+
   def show
     @today = Date.current
     @from = @today.beginning_of_month

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,17 @@ module ApplicationHelper
   def languages_option
     Language.all.map { |language| [t("language.#{language.name}"), language.id] }
   end
+
+  def time_reservation_rate(date)
+    lessons_for_time = Lesson.where('? <= started_at AND started_at <= ?', date.in_time_zone.beginning_of_hour, date.in_time_zone.end_of_hour)
+    reserved_lessons = lessons_for_time.reserved
+    reserved_lessons = lessons_for_time.select { |lesson| lesson.lesson_reservation.present? }
+
+    if lessons_for_time.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_lessons.count / lessons_for_time.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
 end

--- a/app/helpers/language_reservation_rates_helper.rb
+++ b/app/helpers/language_reservation_rates_helper.rb
@@ -1,8 +1,7 @@
 module LanguageReservationRatesHelper
   def language_reservation_rate_for_month(language, today)
     lessons_for_month = Lesson.for_month(today).where(teacher_id: language.teachers)
-
-    reserved_lessons = lessons_for_month.select{ |lesson| lesson.lesson_reservation.present?}
+    reserved_lessons = lessons_for_month.reserved
     if lessons_for_month.count.zero?
       '--'
     else
@@ -13,7 +12,7 @@ module LanguageReservationRatesHelper
 
   def language_reservation_reate_for_day(language, date)
     lessons_for_day = Lesson.where(started_at: date.in_time_zone.all_day).where(teacher_id: language.teachers)
-    reserved_lessons = lessons_for_day.select{ |lesson| lesson.lesson_reservation.present?}
+    reserved_lessons = lessons_for_day.reserved
     if lessons_for_day.count.zero?
       '--'
     else

--- a/app/helpers/language_reservation_rates_helper.rb
+++ b/app/helpers/language_reservation_rates_helper.rb
@@ -1,0 +1,24 @@
+module LanguageReservationRatesHelper
+  def language_reservation_rate_for_month(language, today)
+    lessons_for_month = Lesson.for_month(today).where(teacher_id: language.teachers)
+
+    reserved_lessons = lessons_for_month.select{ |lesson| lesson.lesson_reservation.present?}
+    if lessons_for_month.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_lessons.count / lessons_for_month.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
+
+  def language_reservation_reate_for_day(language, date)
+    lessons_for_day = Lesson.where(started_at: date.in_time_zone.all_day).where(teacher_id: language.teachers)
+    reserved_lessons = lessons_for_day.select{ |lesson| lesson.lesson_reservation.present?}
+    if lessons_for_day.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_lessons.count / lessons_for_day.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
+end

--- a/app/helpers/teacher_reservation_rates_helper.rb
+++ b/app/helpers/teacher_reservation_rates_helper.rb
@@ -1,0 +1,23 @@
+module TeacherReservationRatesHelper
+  def reservation_rate_for_month(teacher, today)
+    lessons_for_month = teacher.lessons.where(started_at: today.in_time_zone.all_month)
+    reserved_lessons_for_month = lessons_for_month.select{|lesson| lesson.lesson_reservation.present?}
+    if lessons_for_month.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_lessons_for_month.count / lessons_for_month.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
+
+  def reservation_rate_for_day(teacher, date)
+    lessons_for_day = teacher.lessons.where(started_at: date.in_time_zone.all_day)
+    reserved_lessons = lessons_for_day.select{|lesson| lesson.lesson_reservation.present?}
+    if lessons_for_day.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_lessons.count / lessons_for_day.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
+end

--- a/app/helpers/teacher_reservation_rates_helper.rb
+++ b/app/helpers/teacher_reservation_rates_helper.rb
@@ -1,7 +1,7 @@
 module TeacherReservationRatesHelper
   def reservation_rate_for_month(teacher, today)
-    lessons_for_month = teacher.lessons.where(started_at: today.in_time_zone.all_month)
-    reserved_lessons_for_month = lessons_for_month.select{|lesson| lesson.lesson_reservation.present?}
+    lessons_for_month = teacher.lessons.for_month(today)
+    reserved_lessons_for_month = lessons_for_month.reserved
     if lessons_for_month.count.zero?
       '--'
     else
@@ -12,7 +12,7 @@ module TeacherReservationRatesHelper
 
   def reservation_rate_for_day(teacher, date)
     lessons_for_day = teacher.lessons.where(started_at: date.in_time_zone.all_day)
-    reserved_lessons = lessons_for_day.select{|lesson| lesson.lesson_reservation.present?}
+    reserved_lessons = lessons_for_day.reserved
     if lessons_for_day.count.zero?
       '--'
     else

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,3 +1,3 @@
 class Language < ApplicationRecord
-  has_many :teachers
+  has_many :teachers, dependent: :restrict_with_exception
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -9,7 +9,7 @@ class Lesson < ApplicationRecord
   scope :past, -> { where('started_at <= ?', Time.current) }
   scope :reserved, -> { where(id: LessonReservation.select(:lesson_id)) }
   scope :not_reserved, -> { where.not(id: LessonReservation.select(:lesson_id)) }
-  scope :for_month, -> (today) {where(started_at: today.in_time_zone.all_month)}
+  scope :for_month, ->(today) { where(started_at: today.in_time_zone.all_month) }
   scope :search_by_teacher_name, ->(teacher_name) { where('teachers.name LIKE ?', "%#{teacher_name}%") }
   scope :search_by_language_name, ->(language_id) { where('languages.id::text LIKE ?', language_id) }
   scope :search_by_date, ->(date) { where(started_at: date.in_time_zone.all_day) }

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -9,6 +9,7 @@ class Lesson < ApplicationRecord
   scope :past, -> { where('started_at <= ?', Time.current) }
   scope :reserved, -> { where(id: LessonReservation.select(:lesson_id)) }
   scope :not_reserved, -> { where.not(id: LessonReservation.select(:lesson_id)) }
+  scope :for_month, -> (today) {where(started_at: today.in_time_zone.all_month)}
   scope :search_by_teacher_name, ->(teacher_name) { where('teachers.name LIKE ?', "%#{teacher_name}%") }
   scope :search_by_language_name, ->(language_id) { where('languages.id::text LIKE ?', language_id) }
   scope :search_by_date, ->(date) { where(started_at: date.in_time_zone.all_day) }

--- a/app/models/lesson_reservation.rb
+++ b/app/models/lesson_reservation.rb
@@ -1,4 +1,5 @@
 class LessonReservation < ApplicationRecord
   belongs_to :student
   belongs_to :lesson
+  validates :student_id, uniqueness: { scope: :lesson_id}
 end

--- a/app/models/lesson_reservation.rb
+++ b/app/models/lesson_reservation.rb
@@ -1,5 +1,5 @@
 class LessonReservation < ApplicationRecord
   belongs_to :student
   belongs_to :lesson
-  validates :student_id, uniqueness: { scope: :lesson_id}
+  validates :student_id, uniqueness: { scope: :lesson_id }
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,5 +2,5 @@ class Review < ApplicationRecord
   belongs_to :teacher
   belongs_to :lesson
   validates :content, presence: true
-  validates :teacher_id, uniqueness: {scope: :lesson_id}
+  validates :teacher_id, uniqueness: { scope: :lesson_id }
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,4 +2,5 @@ class Review < ApplicationRecord
   belongs_to :teacher
   belongs_to :lesson
   validates :content, presence: true
+  validates :teacher_id, uniqueness: {scope: :lesson_id}
 end

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,4 +1,5 @@
 %h2 管理者ページ
+%p= link_to '時間別予約率表', time_reservation_rates_path
 %p= link_to '言語一覧', language_path
 %p= link_to '講師一覧', teachers_path
 %p= link_to '講師を作成する', new_teacher_path

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,3 +1,4 @@
 %h2 管理者ページ
+%p= link_to '言語一覧', language_path
 %p= link_to '講師一覧', teachers_path
 %p= link_to '講師を作成する', new_teacher_path

--- a/app/views/language_reservation_rates/show.html.haml
+++ b/app/views/language_reservation_rates/show.html.haml
@@ -1,0 +1,17 @@
+%h2= t("language.#{@language.name}")
+%p 
+  #{@today.month}月の予約率:
+  #{language_reservation_rate_for_month(@language, @today)}%
+%p ※測定不能の場合「--」と表示
+%table
+  - @days.each do |day|
+    %th= day
+  - @dates_for_week.each do |week|
+    %tr
+      - week.each do |date|
+        - if date == @from
+          - date.wday.times do
+            %td
+        %td
+          %p= date.day
+          %p= language_reservation_reate_for_day(@language, date)

--- a/app/views/languages/show.html.haml
+++ b/app/views/languages/show.html.haml
@@ -1,5 +1,7 @@
 %h2 言語一覧
 - @languages.each do |language|
-  %p= t("language.#{language.name}")
+  %p
+  = t("language.#{language.name}")
+  = link_to '予約率', language_reservation_rates_path(language: language)
 
 = paginate @languages

--- a/app/views/languages/show.html.haml
+++ b/app/views/languages/show.html.haml
@@ -1,5 +1,5 @@
 %h2 言語一覧
 - @languages.each do |language|
-  %p= language.name
+  %p= t("language.#{language.name}")
 
 = paginate @languages

--- a/app/views/lessons/new.html.haml
+++ b/app/views/lessons/new.html.haml
@@ -6,3 +6,4 @@
   = f.datetime_field :started_at, min: Date.current
   = f.submit
 = link_to '複数レッスンを同時作成する', new_teachers_multiple_lesson_path
+= link_to '範囲指定でレッスンを作成する', new_teachers_specific_range_lesson_path

--- a/app/views/lessons/new.html.haml
+++ b/app/views/lessons/new.html.haml
@@ -5,3 +5,4 @@
 = form_with(model: @lesson) do |f|
   = f.datetime_field :started_at, min: Date.current
   = f.submit
+= link_to '複数レッスンを同時作成する', new_teachers_multiple_lesson_path

--- a/app/views/teacher_reservation_rates/show.html.haml
+++ b/app/views/teacher_reservation_rates/show.html.haml
@@ -1,0 +1,15 @@
+%h2 #{@teacher.name}さん
+%p #{@today.month}月の予約率: #{reservation_rate_for_month(@teacher, @today)}%
+%p ※測定不能の場合「--」と表示
+%table
+  - @days.each do |day|
+    %th= day
+  - @dates_for_week.each do |week|
+    %tr
+      - week.each do |date|
+        - if date == @from
+          - date.wday.times do
+            %td
+        %td
+          %p= date.day
+          %p= reservation_rate_for_day(@teacher, date)

--- a/app/views/teachers/index.html.haml
+++ b/app/views/teachers/index.html.haml
@@ -3,6 +3,7 @@
   %p
     = teacher.name
     - if admin_signed_in?
+      = link_to '予約率', teacher_reservation_rates_path(teacher: teacher)
       = link_to '削除', teacher_path(teacher), method: :delete
       = link_to '代理ログイン', admin_sign_in_as_teachers_path(teacher: teacher), method: :post
 

--- a/app/views/teachers/multiple_lessons/new.html.haml
+++ b/app/views/teachers/multiple_lessons/new.html.haml
@@ -1,5 +1,5 @@
 %h2 複数レッスン作成画面
 = form_with(url: teachers_multiple_lessons_path) do |f|
   - 3.times do
-    = f.datetime_field 'multiple_lessons[started_at][]'
+    = f.datetime_field 'multiple_lessons[started_at][]', min: Date.current
   = f.submit

--- a/app/views/teachers/multiple_lessons/new.html.haml
+++ b/app/views/teachers/multiple_lessons/new.html.haml
@@ -1,0 +1,5 @@
+%h2 複数レッスン作成画面
+= form_with(url: teachers_multiple_lessons_path) do |f|
+  - 3.times do
+    = f.datetime_field 'multiple_lessons[started_at][]'
+  = f.submit

--- a/app/views/teachers/specific_range_lessons/new.html.haml
+++ b/app/views/teachers/specific_range_lessons/new.html.haml
@@ -1,0 +1,11 @@
+%h2 レッスン範囲指定作成画面
+%p 作成日時の範囲を選択してください
+- timeoption = (7..22).to_a
+= form_with(url: teachers_specific_range_lessons_path) do |f|
+  = f.date_field :date, min: Date.current
+  の
+  = f.select :start_time, timeoption
+  時〜
+  = f.select :end_time, timeoption
+  時まで
+  = f.submit '作成'

--- a/app/views/time_reservation_rates/show.html.haml
+++ b/app/views/time_reservation_rates/show.html.haml
@@ -1,0 +1,23 @@
+%h2 #{@today.month}月の時間別予約率表
+%p ※赤色 → 予約率86%以上
+%p ※桃色 → 予約率51〜85%
+%p ※青色 → 予約率50%以下
+%p ※レッスンの予定がない場合"--"
+
+%table
+  %th
+  - @dates_in_month.each do |date|
+    %th= date.day
+  - @times.each do |time|
+    %tr
+      %td #{time}時
+      - @dates_in_month.each do |date|
+        - reservation_rate = time_reservation_rate(date + time.hours)
+        -if reservation_rate == '--'
+          %td= reservation_rate
+        - elsif reservation_rate >= 86
+          %td.high= time_reservation_rate(date + time.hours)
+        - elsif reservation_rate <= 50 
+          %td.low= time_reservation_rate(date + time.hours)
+        - else
+          %td.middle= time_reservation_rate(date + time.hours)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   namespace :teachers do
     resource :lesson, only: [:show]
     resource :past_lesson, only: %i[show]
+    resources :multiple_lessons, only: %i[new create]
   end
   resources :teachers, only: %i[index new create show destroy]
   namespace :students do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     resource :lesson, only: [:show]
     resource :past_lesson, only: %i[show]
     resources :multiple_lessons, only: %i[new create]
+    resources :specific_range_lessons, only: %i[new create]
   end
   resources :teachers, only: %i[index new create show destroy]
   namespace :students do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,5 @@ Rails.application.routes.draw do
   resources :reviews, only: %i[new create show destroy]
   resource :teacher_reservation_rates, only: %i[show]
   resource :language_reservation_rates, only: %i[show]
+  resource :time_reservation_rates, only: %i[show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,6 @@ Rails.application.routes.draw do
   resources :purchase_tickets, only: %i[new create]
   resources :lesson_reservations, only: %i[create destroy]
   resources :reviews, only: %i[new create show destroy]
+  resource :teacher_reservation_rates, only: %i[show]
+  resource :language_reservation_rates, only: %i[show]
 end


### PR DESCRIPTION
## 概要
レッスンフィードバックの実装により、ユーザー向けのサービスが大きく充実しました。一方で、ユーザーからは予約がしにくいというクレームを受けるようになってきました。時間帯や講師、レッスン言語によって、レッスン枠を空けても予約がされなかったり、逆に予約が過密しすぎてしまう状況があるためです。運営チームはこの事態を解決するために、予約データから以下のような情報を参照できるように管理機能を充実させようとしています。

## 要件
どの時間帯に一番予約が集中しているか見える化したい
日付を縦列、時刻を横軸として、それぞれ交差する日時の予約率（予約数 / レッスン枠数）を表示する
50%以下は青、51〜85%は薄赤、86%〜は赤でマスを表示する
表示する"日にち範囲"はフォームで指定できるようにする
※本来”日時範囲”とありましたが、川村さんと話し今回は日程のみ範囲指定できるようにしました

講師毎の予約率を見える化したい
月毎の講師別予約率を参照できるようにする
詳細として、日毎の予約率も参照できるようにする
曜日による違いも見たいため、曜日情報も表示すること
言語別の予約率を見える化したい

月毎の言語別予約率を参照できるようにする
詳細として、日毎の予約率も参照できるようにする
曜日による違いも見たいため、曜日情報も表示すること

また、サービスの人気に伴い、講師のレッスン登録のしやすさも重要になりました。以下の機能を実装してレッスン登録をスムーズにしましょう。
日時の範囲指定でレッスン枠を一括で登録できるように
日時の複数指定でレッスン枠を一括で登録できるように