### PR TITLE
演習3-4（外国語レッスンのマッチングサービス3週目）

### DIFF
--- a/app/controllers/choice_monthly_plans_controller.rb
+++ b/app/controllers/choice_monthly_plans_controller.rb
@@ -1,0 +1,45 @@
+class ChoiceMonthlyPlansController < ApplicationController
+  before_action :set_choice_monthly_plan, only: %i[show edit update destroy]
+
+  def new
+    @choice_monthly_plan = current_student.build_choice_monthly_plan
+  end
+
+  def create
+    @choice_monthly_plan = current_student.build_choice_monthly_plan(choice_monthly_plan_params)
+    if @choice_monthly_plan.save
+      redirect_to student_path(current_student), notice: 'プランを選択しました'
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @choice_monthly_plan.update(choice_monthly_plan_params)
+      redirect_to student_path(current_student), notice: 'プランを変更しました'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @choice_monthly_plan.destroy!
+    redirect_to student_path(current_student), notice: 'プランを休止しました'
+  end
+
+  private
+
+  def choice_monthly_plan_params
+    params.require(:choice_monthly_plan).permit %i[monthly_plan_id student_id]
+  end
+
+  def set_choice_monthly_plan
+    @choice_monthly_plan = current_student.choice_monthly_plan
+  end
+end

--- a/app/controllers/choice_monthly_plans_controller.rb
+++ b/app/controllers/choice_monthly_plans_controller.rb
@@ -8,6 +8,7 @@ class ChoiceMonthlyPlansController < ApplicationController
   def create
     @choice_monthly_plan = current_student.build_choice_monthly_plan(choice_monthly_plan_params)
     if @choice_monthly_plan.save
+      current_student.purchase_tickets.create!(ticket_id: @choice_monthly_plan.monthly_plan.ticket.id, deadline: Date.current.end_of_month)
       redirect_to student_path(current_student), notice: 'プランを選択しました'
     else
       render :new

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -1,4 +1,10 @@
 class ChoiceMonthlyPlan < ApplicationRecord
   belongs_to :monthly_plan
   belongs_to :student
+
+  def self.ticket_subscription
+    self.all.each do |plan|
+      plan.student.purchase_tickets.create(ticket_id: plan.monthly_plan.ticket.id, deadline: Date.current.end_of_month)
+    end
+  end
 end

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -3,7 +3,7 @@ class ChoiceMonthlyPlan < ApplicationRecord
   belongs_to :student
 
   def self.ticket_subscription
-    self.all.each do |plan|
+    self.all.find_each do |plan|
       plan.student.purchase_tickets.create(ticket_id: plan.monthly_plan.ticket.id, deadline: Date.current.end_of_month)
     end
   end

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -1,0 +1,4 @@
+class ChoiceMonthlyPlan < ApplicationRecord
+  belongs_to :monthly_plan
+  belongs_to :student
+end

--- a/app/models/monthly_plan.rb
+++ b/app/models/monthly_plan.rb
@@ -1,0 +1,4 @@
+class MonthlyPlan < ApplicationRecord
+  belongs_to :ticket
+  has_many :choice_monthly_plans
+end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -5,11 +5,14 @@ class Student < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :purchase_tickets, dependent: :destroy
   has_many :tickets, through: :purchase_tickets, source: :ticket
+  has_many :purchase_tickets_within_deadline, -> { where(deadline: Date.current..) }, class_name: 'PurchaseTicket'
+  has_many :valid_tickets, through: :purchase_tickets_within_deadline, source: :ticket
   has_many :lesson_reservations, dependent: :destroy
   has_many :lessons, through: :lesson_reservations, source: :lesson
+  has_one :choice_monthly_plan
 
   def remaining_lesson_count
-    self_lesson_count = self.tickets.sum(:lesson_count)
+    self_lesson_count = self.valid_tickets.sum(:lesson_count)
     self_reservations = self.lesson_reservations
     self_lesson_count - self_reservations.count
   end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,2 +1,3 @@
 class Ticket < ApplicationRecord
+  has_one :monthly_ticket
 end

--- a/app/views/choice_monthly_plans/edit.haml
+++ b/app/views/choice_monthly_plans/edit.haml
@@ -1,0 +1,4 @@
+%h2 定期プラン変更画面
+= form_with(model: @choice_monthly_plan) do |f|
+  = f.select :monthly_plan_id, MonthlyPlan.all.map{ |plan| [plan.name, plan.id]}
+  = f.submit '変更する'

--- a/app/views/choice_monthly_plans/new.html.haml
+++ b/app/views/choice_monthly_plans/new.html.haml
@@ -1,0 +1,4 @@
+%h2 定期プラン選択画面
+= form_with(model: @choice_monthly_plan) do |f|
+  = f.select :monthly_plan_id, MonthlyPlan.all.map{ |plan| [plan.name, plan.id]}
+  = f.submit

--- a/app/views/choice_monthly_plans/show.haml
+++ b/app/views/choice_monthly_plans/show.haml
@@ -1,0 +1,4 @@
+%h2 現在のプラン
+%p= @choice_monthly_plan.monthly_plan.name
+%p= link_to 'プランを変更する', edit_choice_monthly_plan_path
+%p= link_to 'プランを休止する', choice_monthly_plan_path, method: :delete

--- a/app/views/purchase_tickets/new.html.haml
+++ b/app/views/purchase_tickets/new.html.haml
@@ -1,5 +1,5 @@
 %h2 チケット購入画面
-- tickets = Ticket.all.map { |ticket| ["#{ticket.fee}円: #{ticket.lesson_count}回分", ticket.id] }
+- tickets = Ticket.where(fee: [2200,  5500, 8250]).map { |ticket| ["#{ticket.fee}円: #{ticket.lesson_count}回分", ticket.id] }
 = form_with(model: @purchase_ticket) do |f|
   = f.select :ticket_id, tickets
   = f.submit

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -5,3 +5,7 @@
 %p= link_to '編集', edit_student_registration_path
 %p= link_to 'レッスン履歴', students_past_lesson_path(student: @student)
 %p= link_to 'チケットを購入する', new_purchase_ticket_path
+- if @student.choice_monthly_plan.present?
+  %p= link_to '定期プランを確認する', choice_monthly_plan_path(@student.choice_monthly_plan)
+- else
+  %p= link_to '定期プランに加入する', new_choice_monthly_plan_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,5 @@ Rails.application.routes.draw do
   resource :teacher_reservation_rates, only: %i[show]
   resource :language_reservation_rates, only: %i[show]
   resource :time_reservation_rates, only: %i[show]
+  resources :choice_monthly_plans
 end

--- a/db/migrate/20210825040527_create_monthly_plans.rb
+++ b/db/migrate/20210825040527_create_monthly_plans.rb
@@ -1,0 +1,11 @@
+class CreateMonthlyPlans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :monthly_plans do |t|
+      t.string :name, null: false
+      t.references :ticket, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :monthly_plans, %i[name ticket_id], unique: true
+  end
+end

--- a/db/migrate/20210825054127_create_choice_monthly_plans.rb
+++ b/db/migrate/20210825054127_create_choice_monthly_plans.rb
@@ -1,0 +1,11 @@
+class CreateChoiceMonthlyPlans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :choice_monthly_plans do |t|
+      t.references :monthly_plan, null: false, foreign_key: true, index: false
+      t.references :student, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :choice_monthly_plans, %i[monthly_plan_id student_id], unique: true
+  end
+end

--- a/db/migrate/20210825055743_add_column_to_purchase_ticket.rb
+++ b/db/migrate/20210825055743_add_column_to_purchase_ticket.rb
@@ -1,0 +1,5 @@
+class AddColumnToPurchaseTicket < ActiveRecord::Migration[6.1]
+  def change
+    add_column :purchase_tickets, :deadline, :date, null: false, default: Date.current.since(1000.years)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_22_162132) do
+ActiveRecord::Schema.define(version: 2021_08_25_055743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2021_08_22_162132) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "choice_monthly_plans", force: :cascade do |t|
+    t.bigint "monthly_plan_id", null: false
+    t.bigint "student_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["monthly_plan_id", "student_id"], name: "index_choice_monthly_plans_on_monthly_plan_id_and_student_id", unique: true
+    t.index ["student_id"], name: "index_choice_monthly_plans_on_student_id"
   end
 
   create_table "languages", force: :cascade do |t|
@@ -53,11 +62,21 @@ ActiveRecord::Schema.define(version: 2021_08_22_162132) do
     t.index ["teacher_id"], name: "index_lessons_on_teacher_id"
   end
 
+  create_table "monthly_plans", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "ticket_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "ticket_id"], name: "index_monthly_plans_on_name_and_ticket_id", unique: true
+    t.index ["ticket_id"], name: "index_monthly_plans_on_ticket_id"
+  end
+
   create_table "purchase_tickets", force: :cascade do |t|
     t.bigint "ticket_id", null: false
     t.bigint "student_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "deadline", default: "3021-08-25", null: false
     t.index ["student_id"], name: "index_purchase_tickets_on_student_id"
     t.index ["ticket_id"], name: "index_purchase_tickets_on_ticket_id"
   end
@@ -109,9 +128,12 @@ ActiveRecord::Schema.define(version: 2021_08_22_162132) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "choice_monthly_plans", "monthly_plans"
+  add_foreign_key "choice_monthly_plans", "students"
   add_foreign_key "lesson_reservations", "lessons"
   add_foreign_key "lesson_reservations", "students"
   add_foreign_key "lessons", "teachers"
+  add_foreign_key "monthly_plans", "tickets"
   add_foreign_key "purchase_tickets", "students"
   add_foreign_key "purchase_tickets", "tickets"
   add_foreign_key "reviews", "lessons"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Ticket.create(fee: 7000, lesson_count: 5)
+Ticket.create(fee: 9500, lesson_count: 7)
+Ticket.create(fee: 12000, lesson_count: 10)
+
+MonthlyPlan.create(name: 'light', ticket_id: Ticket.find_by(fee: 7000).id)
+MonthlyPlan.create(name: 'standard', ticket_id: Ticket.find_by(fee: 9500).id)
+MonthlyPlan.create(name: 'heavy', ticket_id: Ticket.find_by(fee: 12000).id)
+
 Admin.create(email: 'admin@example.com', password: 'aaaaaaaa', password_confirmation: 'aaaaaaaa')
 
 Language.create(name: 'thai')

--- a/lib/tasks/monthly_task.rake
+++ b/lib/tasks/monthly_task.rake
@@ -1,0 +1,8 @@
+namespace :monthly_task do
+  desc '定期プランでチケットを購入する処理'
+  task ticket_subscription: :environment do
+    if Date.current == Date.current.beginning_of_month
+      ChoiceMonthlyPlan.ticket_subscription
+    end
+  end
+end


### PR DESCRIPTION
## 課題4
## 概要
サブスクリプション型のサービスへ
サービス運営を続ける中、一部ユーザーからいちいちチケットを買うのが面倒くさいという声があがりはじめました。そこで個別にチケットを買う形から、定期決済の導入をしようと考えました。以下の機能を実装しましょう。

## 要件
定期決済プランを購入できるように
ライトプラン：毎月5回、月額7000円
スタンダードプラン：毎月7回、月額9500円
ヘビープラン：毎月10回、月額12000円
定期決済で追加されたチケットは追加日から30日以内のみ使えるように
補足：従来型の都度購入のチケットは無期限で使える
プラン変更を行うことができるように
旧プランのチケットは期限内であれば引き続き使えるように
プランを休止できるように
休止前のプランチケットが残っている場合は、期限内であれば引き続き使えるように

## 注意事項
下記に関して、相談の上要件から外しました
・定期決済の決済履歴を確認できるように
・定期決済で使用しているカード情報を変更できるように

herokuにはあげてませんが、herokuにあげた際にスケジューラで毎日rakeが実行される場合を想定して作りました
planを購入すると、毎月一日にシステム内で該当するチケット（期限一ヶ月間なのでその月内のみ有効）が購入される仕様となっています